### PR TITLE
fix: 사파리 브라우저 모바일 이미지 비율 깨짐 버그 수정

### DIFF
--- a/src/Components/Button/CheckBox.jsx
+++ b/src/Components/Button/CheckBox.jsx
@@ -23,7 +23,7 @@ const CheckBox = ({ checked, onClick, itemId }) => {
                 : "assets/checkmark-dark.png"
             }
             alt="check mark"
-            style={{ width: "100%", display: "block" }}
+            className={styles.img}
           />
         </div>
       )}

--- a/src/Components/Button/CheckBox.module.css
+++ b/src/Components/Button/CheckBox.module.css
@@ -14,6 +14,11 @@
   width: 29px;
   height: 23px;
 }
+.img {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
 
 @media screen and (max-width: 768px) {
   .checkbox {


### PR DESCRIPTION
img 태그의 스타일을 height:auto; 에서 height: 100%로 수정해야 사파리에서 적용됨. 


Closes #6 